### PR TITLE
Changed from battery current control to motor current control as main…

### DIFF
--- a/TSDZ2_Controller_vM0.19.C_and_TSDZ2_Configurator_0.3.7_con_codice_0.19_Stable/src/controller/adc.c
+++ b/TSDZ2_Controller_vM0.19.C_and_TSDZ2_Configurator_0.3.7_con_codice_0.19_Stable/src/controller/adc.c
@@ -85,7 +85,7 @@ void adc_init(void)
   ui16_adc_torque_sensor_offset >>= 4;
 
   ui8_adc_torque_sensor_min_value = ((uint8_t) ui16_adc_torque_sensor_offset) + ADC_TORQUE_SENSOR_THRESHOLD;
-  ui8_adc_torque_sensor_max_value = ui8_adc_torque_sensor_min_value + 32;
+  ui8_adc_torque_sensor_max_value = 255;
 }
 
 //=================================================================================================

--- a/TSDZ2_Controller_vM0.19.C_and_TSDZ2_Configurator_0.3.7_con_codice_0.19_Stable/src/controller/ebike_app.h
+++ b/TSDZ2_Controller_vM0.19.C_and_TSDZ2_Configurator_0.3.7_con_codice_0.19_Stable/src/controller/ebike_app.h
@@ -68,6 +68,7 @@ extern volatile uint8_t ui8_adc_torque_sensor_max_value;
 extern volatile uint8_t ui8_adc_battery_current_offset;
 extern volatile uint8_t ui8_ebike_app_state;
 extern volatile uint8_t ui8_adc_target_battery_max_current;
+extern volatile uint8_t ui8_adc_target_motor_max_current;
 extern volatile uint16_t ui16_pas_pwm_cycles_ticks;
 extern volatile uint8_t ui8_pas_direction;
 extern volatile uint8_t ui8_pedaling_direction;


### PR DESCRIPTION
Changed from battery current control to motor current control as main control loop and fixed some issues with displaying of errors. Because when mode was changed errors could not be shown anymore.
Also when the start of temperature control is reached the display will start to show the blinking error E06. When the max temperature is reached it will become solid.
Also increased the detectable range of the torque sensor to the maximum. Originally it can detect 32 ADC steps and now it detects the possible maximum.